### PR TITLE
feat(support): Add Laravel 13 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['8.2', '8.3', '8.4']
-        laravel: ['10.*', '11.*', '12.*', '13.*']
+        laravel: ['11.*', '12.*', '13.*']
         exclude:
           - php: '8.2'
             laravel: '13.*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.2', '8.3', '8.4']
+        laravel: ['10.*', '11.*', '12.*', '13.*']
+        exclude:
+          - php: '8.2'
+            laravel: '13.*'
+
+    name: PHP ${{ matrix.php }} – Laravel ${{ matrix.laravel }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: mbstring
+          coverage: none
+
+      - name: Set Laravel version
+        run: composer require "illuminate/support:${{ matrix.laravel }}" --no-interaction --no-update
+
+      - name: Install dependencies
+        run: composer update --prefer-dist --no-interaction --no-progress
+
+      - name: Run tests
+        run: vendor/bin/pest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Laravel 13 support.
+- CI workflow with Pest tests.
+
+### Changed
+- Minimum Laravel version is now 11.x.
+- Minimum Pest version is now 3.x.
+
+### Removed
+- Laravel 10 support.
+
 ## [0.1.3] - 10 Feb 2018
 ### Added
 - Laravel 5.6 compatibility.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,18 @@ method returns both `null` and some other data-type, so the solution is to
 return a null-class. The `NullCarbon` class is a null-class implementation of
 Laravel's Carbon class.
 
+## Version Support
+
+| Laravel | PHP        | Package |
+|---------|------------|---------|
+| 10.x    | 8.1+       | 3.x     |
+| 11.x    | 8.2+       | 3.x     |
+| 12.x    | 8.2+       | 3.x     |
+| 13.x    | 8.3+       | 3.x     |
+
 ## Prerequisites
-- PHP >= 7.1.3
-- Laravel >= 5.5
+- PHP >= 8.2
+- Laravel >= 10.0
 
 ## Installation
 ```

--- a/README.md
+++ b/README.md
@@ -12,14 +12,13 @@ Laravel's Carbon class.
 
 | Laravel | PHP        | Package |
 |---------|------------|---------|
-| 10.x    | 8.1+       | 3.x     |
 | 11.x    | 8.2+       | 3.x     |
 | 12.x    | 8.2+       | 3.x     |
 | 13.x    | 8.3+       | 3.x     |
 
 ## Prerequisites
 - PHP >= 8.2
-- Laravel >= 10.0
+- Laravel >= 11.0
 
 ## Installation
 ```

--- a/composer.json
+++ b/composer.json
@@ -9,10 +9,13 @@
         }
     ],
     "require": {
-        "illuminate/support": "^11.0"
+        "php": "^8.2",
+        "illuminate/support": "^10.0|^11.0|^12.0|^13.0"
     },
     "require-dev": {
-        "symfony/thanks" : "^1.2"
+        "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
+        "pestphp/pest": "^2.0|^3.0",
+        "symfony/thanks": "^1.2"
     },
     "autoload": {
         "psr-4": {
@@ -22,6 +25,12 @@
     "autoload-dev": {
         "psr-4": {
             "GeneaLabs\\LaravelNullCarbon\\Tests\\": "tests/"
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "pestphp/pest-plugin": true,
+            "symfony/thanks": true
         }
     },
     "minimum-stability": "stable"

--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,11 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/support": "^10.0|^11.0|^12.0|^13.0"
+        "illuminate/support": "^11.0|^12.0|^13.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
-        "pestphp/pest": "^2.0|^3.0",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
+        "pestphp/pest": "^3.0",
         "symfony/thanks": "^1.2"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    bootstrap="vendor/autoload.php"
+    colors="true"
+>
+    <testsuites>
+        <testsuite name="Tests">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/NullCarbonTest.php
+++ b/tests/NullCarbonTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use GeneaLabs\LaravelNullCarbon\NullCarbon;
+use Illuminate\Support\Carbon;
+
+it('extends Carbon', function () {
+    $nullCarbon = new NullCarbon;
+
+    expect($nullCarbon)->toBeInstanceOf(Carbon::class);
+});
+
+it('returns empty string when cast to string', function () {
+    $nullCarbon = new NullCarbon;
+
+    expect((string) $nullCarbon)->toBe('');
+});
+
+it('returns empty string when formatted', function () {
+    $nullCarbon = new NullCarbon;
+
+    expect($nullCarbon->format('Y-m-d'))->toBe('');
+});
+
+it('returns json encoded null when serialized', function () {
+    $nullCarbon = new NullCarbon;
+
+    expect($nullCarbon->jsonSerialize())->toBe('null');
+});
+
+it('can be instantiated without arguments', function () {
+    $nullCarbon = new NullCarbon;
+
+    expect($nullCarbon)->not->toBeNull();
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,3 @@
+<?php
+
+// Pest configuration


### PR DESCRIPTION
## Summary
Add Laravel 13 support by updating illuminate/support constraint, CI matrix, and documentation. Drops Laravel 10 support due to Pest 3/PHPUnit 11 incompatibility.

## Acceptance Criteria
- [x] `composer.json` version constraint updated to include Laravel 13.x
- [x] CI matrix includes a Laravel 13 job and all tests pass with zero failures on Laravel 13
- [x] Any Laravel 13 breaking changes affecting this package are identified and resolved
- [x] README version support table updated to include Laravel 13
- [x] `composer update` completes without conflicts under Laravel 13
- [x] laravel-null-carbon installs and runs without errors on Laravel 13
- [x] All existing tests pass on Laravel 13 in CI
- [x] composer.json requires constraint is updated to include Laravel 13
- [x] CHANGELOG documents Laravel 13 support

Fixes #26
